### PR TITLE
add PR links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ For meeting updates and up-to-date communication, see our [substack](https://www
 
 ## Methodology Queue
 
-| Category           | Methodology                                      | Developer     |
-| ------------------ | ------------------------------------------------ | -------------- |
-| Solar              | Self-Consumed                                    | PeerCo         |
-| Energy Efficiency  | Whole-building Metered Lighting                  | C3             |
-| Energy Efficiency  | Existing Construction Whole-building Simulation  | Auros Group    |
-| Energy Efficiency  | New Construction Whole-building Simulation       | Auros Group    |
-| Electrification    | NREL ResStock Deemed Loadshapes                  | WattCarbon     |
+| Category           | Methodology                                      | Developer      | Pull Request       | 
+| ------------------ | ------------------------------------------------ | -------------- | ------------------ |
+| Solar              | Self-Consumed                                    | PeerCo         | wattcarbon/WEATS#2 |
+| Energy Efficiency  | Whole-building Metered Lighting                  | C3             | wattcarbon/WEATS#3 | 
+| Energy Efficiency  | Existing Construction Whole-building Simulation  | Auros Group    | wattcarbon/WEATS#5 |
+| Energy Efficiency  | New Construction Whole-building Simulation       | Auros Group    | wattcarbon/WEATS#4 |
+| Electrification    | NREL ResStock Deemed Loadshapes                  | WattCarbon     | wattcarbon/WEATS#6 | 
 
 ## Published Methodologies
 


### PR DESCRIPTION
Add links to the PRs for each methodology's PR. 

Makes PRs and discussion easier to find for those less familiar with Github. 

Downside: adds additional step for updating README for new methodologies.